### PR TITLE
Added note to BCR-0004 re BC32 vs Base64

### DIFF
--- a/papers/bcr-0004-bc32.md
+++ b/papers/bcr-0004-bc32.md
@@ -42,6 +42,8 @@ The following table compares the relative efficiency of various binary-to-text e
 | base32, bech32, BC32 (not including checksum) | 32 | 5.0 | 62.5% |
 | hexadecimal | 16 | 4.0 | 50% |
 
+**✳️ Note:** Although it would appear that base32 is always less efficient than base64, this is not the case when encoding a payload for transport in QR codes. Because BC32 uses a character set optimized for the more efficient QR code alphanumeric mode, a payload of 1000 random bytes results in a QR code 13% less dense when the payload is encoded with BC32, compared to the same payload encoded as Base64.
+
 ### Implementations
 
 Current implementations:


### PR DESCRIPTION
-----BEGIN PGP SIGNED MESSAGE-----
Hash: SHA512

Added note to BCR-0004 about the superiority of BC32 to Base64 in constructing QR codes.	a6b9744	Wolf McNally <wolf@wolfmcnally.com>	May 7, 2020 at 1:18 AM
-----BEGIN PGP SIGNATURE-----
Comment: GPGTools - https://gpgtools.org

iQIzBAEBCgAdFiEElDZS7jhEF2DD3DU2S2wvz4lHgK4FAl6zxI4ACgkQS2wvz4lH
gK6Scw//SjqUIYVKgl/350kLCHTnvqOmE9K5XvT33x6CwV4RiLpFd11pdEyC/ftk
VP09A56gRRjy0Wv36/2Kvse4prLgVOSTEPpxOiD+wxgKfBvS9IRzMZcWcSrJ50xX
c/dS9vJcn3W0DTZQ/EoFbqPdg4dHocse9VpafzSCVNpf74KkDLZo8QSyctUpjx3A
wo0bCcASol8Kam4Qpt5lc7ETLd1aC0tnME488G0ZwvAWCcJpy7dkBPsCBfFovPqQ
axiOsEq4MQi/ElJs8VYnxxUBKEHjr8DdYedO3nHiSTAOjJPvXAlBSF6+/Z85Vyq2
2wgBRK8lJg99x7wwf7bcwoVPjphpdwaBnGojsBiSaK0iyoQUDvsR8/JGSKc1W+wj
CrGQ+ogfL9n701eC6HTddk7UcfcFdkgoVaWHJCrXBsx82kPUxkKn1EiEtzLfV6My
z05BzcEDsXomTzwjCDOda7CzOvcFElSAQMjSEsP0ZFiV+PeAd4x3MlQnEBRLIoIl
6lRMPe4Se6jy97eNMh3YMfMluPmdwTuDi2GzAurhIpSefq05VClPVCa3JBogr8D+
rAcTkrdwAhmrM9HWMS5G7vbZ4KJwvf5fynC3qg6nm3TNGM7lh8/hy2QxDZlQKM63
hUiuDLD7Fu0LiUlBH+F4Cn19s9ouwr2pQ/xiX45fBIH9jH5zUf4=
=ut9N
-----END PGP SIGNATURE-----
