### PR TITLE
Remove erroneous additional bytes in crypto-bip39 test vector

### DIFF
--- a/papers/bcr-2020-006-urtypes.md
+++ b/papers/bcr-2020-006-urtypes.md
@@ -227,19 +227,18 @@ A2                      # map(2)
    02                   # unsigned(2) lang:
    62                   # text(2)
       656E              # "en"
-      19 47DA                          # unsigned(18394)
 ```
 
 * As a hex string:
 
 ```
-A2018C66736869656C646567726F75706565726F6465656177616B65646C6F636B6773617573616765646361736865676C6172656477617665646372657765666C616D6565676C6F76650262656E1947DA
+A2018C66736869656C646567726F75706565726F6465656177616B65646C6F636B6773617573616765646361736865676C6172656477617665646372657765666C616D6565676C6F76650262656E
 ```
 
 * As a UR:
 
 ```
-ur:crypto-bip39/oeadlkiyjkisinihjzieihiojpjlkpjoihihjpjlieihihhskthsjeihiejzjliajeiojkhskpjkhsioihieiahsjkisihiojzhsjpihiekthskoihieiajpihktihiyjzhsjnihihiojzjlkoihaoidihjtcffltnwyhplfmn
+ur:crypto-bip39/oeadlkiyjkisinihjzieihiojpjlkpjoihihjpjlieihihhskthsjeihiejzjliajeiojkhskpjkhsioihieiahsjkisihiojzhsjpihiekthskoihieiajpihktihiyjzhsjnihihiojzjlkoihaoidihjtrkkndede
 ```
 
 * UR as QR Code:


### PR DESCRIPTION
The test vector for `crypto-bip39` has a few extra erroneous bytes that appear to have been copied over from the `crypto-seed` test vector (specifically, the birthdate field). The PR removes them. Apologies that I haven't updated the QR code image as well.