### PR TITLE
Add taproot script expression tag to crypto-output

### DIFF
--- a/papers/bcr-2020-010-output-desc.md
+++ b/papers/bcr-2020-010-output-desc.md
@@ -51,7 +51,7 @@ multisig = #6.406(multikey)
 sorted-multisig = #6.407(multi-key)
 address = #6.307(crypto-address)
 raw-script = #6.408(script-bytes)
-taproot = #6.409(key_exp)
+taproot = #6.409(script_exp)
 
 threshold = 1
 keys = 2

--- a/papers/bcr-2020-010-output-desc.md
+++ b/papers/bcr-2020-010-output-desc.md
@@ -6,7 +6,7 @@
 
 Authors: Wolf McNally, Christopher Allen<br/>
 Date: June 8, 2020<br/>
-Revised: June 25, 2020
+Revised: November 8, 2021
 
 ---
 
@@ -33,7 +33,8 @@ script_exp = (
   multisig /                  ; multi
   sorted-multisig /           ; sortedmulti
   address /                   ; addr
-  raw-script                  ; raw
+  raw-script /                ; raw
+  taproot                     ; tr
 )
 
 script-hash = #6.400(script_exp)
@@ -50,6 +51,7 @@ multisig = #6.406(multikey)
 sorted-multisig = #6.407(multi-key)
 address = #6.307(crypto-address)
 raw-script = #6.408(script-bytes)
+taproot = #6.409(key_exp)
 
 threshold = 1
 keys = 2


### PR DESCRIPTION
This PR adds the `tr()` script expression tag to `crypto-output` as per [BIP386](https://github.com/bitcoin/bips/blob/master/bip-0386.mediawiki).

